### PR TITLE
Feat: [#6] secrets 관리

### DIFF
--- a/sharkle/manage.py
+++ b/sharkle/manage.py
@@ -2,10 +2,11 @@
 """Django's command-line utility for administrative tasks."""
 import os
 import sys
-
+import dotenv
 
 def main():
     """Run administrative tasks."""
+    dotenv.load_dotenv()    # load env
     os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'sharkle.settings.development') # default dev setting
     try:
         from django.core.management import execute_from_command_line

--- a/sharkle/requirements.txt
+++ b/sharkle/requirements.txt
@@ -5,4 +5,4 @@ pytz==2021.1
 sqlparse==0.4.1
 django-debug-toolbar==2.2
 djangorestframework==3.11.1
-
+python-dotenv

--- a/sharkle/sharkle/settings/base.py
+++ b/sharkle/sharkle/settings/base.py
@@ -9,13 +9,12 @@ https://docs.djangoproject.com/en/3.2/topics/settings/
 For the full list of settings and their values, see
 https://docs.djangoproject.com/en/3.2/ref/settings/
 """
-
 from pathlib import Path
+import os
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 # since this file in settings dir
 BASE_DIR = Path(__file__).resolve().parent.parent.parent
-
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/3.2/howto/deployment/checklist/
@@ -23,7 +22,7 @@ BASE_DIR = Path(__file__).resolve().parent.parent.parent
 # SECURITY WARNING: keep the secret key used in production secret!
 # SECRET_KEY = 'django-insecure-(tz282!@3q_jj&74(y)o(0_@%mi$rey!6190yy_+@-b$bxc@rs'
 # above secret key will not be used
-SECRET_KEY = 'SECRET'
+SECRET_KEY = os.environ.get('SECRET_KEY')
 
 
 # Application definition

--- a/sharkle/sharkle/settings/development.py
+++ b/sharkle/sharkle/settings/development.py
@@ -16,8 +16,8 @@ DATABASES = {
         'HOST': 'localhost',
         'PORT': 3306,
         'NAME': 'sharkle',
-        'USER': 'sharkle-server',
-        'PASSWORD': 'sharkleDB^_^',
+        'USER': os.environ.get(('DB_USER')),
+        'PASSWORD': os.environ.get(('DB_PASSWORD')),
         'OPTIONS': { # for emoji
             'charset': 'utf8mb4',
             'use_unicode': True,

--- a/sharkle/sharkle/settings/production.py
+++ b/sharkle/sharkle/settings/production.py
@@ -7,11 +7,11 @@ ALLOWED_HOSTS = ['127.0.0.1', ]
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.mysql',
-        'HOST': 'RDS',
+        'HOST': os.environ.get(('DB_HOST')),
         'PORT': 3306,
         'NAME': 'sharkle',
-        'USER': 'sharkle-server',
-        'PASSWORD': 'DB_PASSWORD',
+        'USER': os.environ.get(('DB_USER')),
+        'PASSWORD': os.environ.get('DB_PASSWORD'),
         'OPTIONS': { # for emoji
             'charset': 'utf8mb4',
             'use_unicode': True,


### PR DESCRIPTION
해결된 이슈 번호 : resolves #6 

## 해결/개선하고자 한 기능 설명
- 장고 시크릿 키(변경했습니다) 등 민감한 정보를 .env 파일로 관리합니다 
- `manage.py` 파일 있는 위치에 슬랙으로 보내드린 파일을 넣어서 쓰시면 됩니다. 

## 실제로 해결/개선한 방식
- 파일을 로드하고 처리하는 데에는 `python-dotenv`를 사용했습니다. django-dotenv, django-environ 등 다른 옵션이 많아서 고민하다가 일단 이걸로.. 했습니다. 
- .env 파일은 초기 `.gitignore`에 이미 설정되어 있어서 아마 안올라갈테지만, 혹시라도 노출되지 않게 유의해주시면 감사하겠습니다!
- `json`으로 관리하는 게 좀 편하긴 한데, `env`로 관리하는 게 조금.. 더 안전하다..? (정확한 비교 근거는 잘 모르겠습니다) 는 얘기가 있어서 이렇게 했습니다. 

## 나중에 추가로 해결/개선해야하는 사항
- 비번도 변경했으니 혹시 이미 로컬에서 mysql 유저 & 비번 생성하셨다면 변경이 필요합니다. 
