### PR TITLE
26/add-allowed-domain-host

### DIFF
--- a/sharkle/sharkle/settings/production.py
+++ b/sharkle/sharkle/settings/production.py
@@ -2,7 +2,7 @@ from sharkle.settings.base import *
 
 DEBUG = False
 
-ALLOWED_HOSTS = ['127.0.0.1', '52.79.151.50']
+ALLOWED_HOSTS = ['127.0.0.1', '52.79.151.50', 'sharkle-server.kro.kr']
 
 DATABASES = {
     'default': {


### PR DESCRIPTION
Resolves #26 

## 해결/개선하고자 한 기능 설명
아이피주소로 매번 접속하기엔 힘드므로, sharkle-server.kro.kr이라는 무료 도메인을 사용하도록 하였습니다. 

## 실제로 해결/개선한 방식
따라서 settings에 allowed host를 추가하였습니다.
