### PR TITLE
Feat [#29] CORS setting

### DIFF
--- a/sharkle/requirements.txt
+++ b/sharkle/requirements.txt
@@ -7,3 +7,4 @@ django-debug-toolbar==2.2
 djangorestframework==3.11.1
 python-dotenv
 djangorestframework-simplejwt==5.0.0
+django-cors-headers==3.11.0

--- a/sharkle/sharkle/settings/base.py
+++ b/sharkle/sharkle/settings/base.py
@@ -38,10 +38,12 @@ INSTALLED_APPS = [
     'django.contrib.sites',
     'rest_framework',
     'rest_framework_simplejwt',
+    'corsheaders',
     'user',
 ]
 
 MIDDLEWARE = [
+    'corsheaders.middleware.CorsMiddleware',
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
@@ -50,6 +52,14 @@ MIDDLEWARE = [
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 ]
+
+CORS_ALLOWED_ORIGINS = [
+    "http://sharkle-web-deploy.s3-website.ap-northeast-2.amazonaws.com",
+    "https://d1hax0jwtd7lvm.cloudfront.net",
+    "http://localhost:3000",
+    "http://127.0.0.1:3000",
+]
+
 
 ROOT_URLCONF = 'sharkle.urls'
 


### PR DESCRIPTION
Resolves #29

## 해결/개선하고자 한 기능 설명
- 프론트 배포 주소 및 로컬 테스트용 주소를 cors 허용하였습니다. 

## 실제로 해결/개선한 방식
- [공식문서](https://pypi.org/project/django-cors-headers/) 참고하였습니다. 프론트용 배포주소라 공개되어도 문제되지 않을 것...? 같아서 하드코딩 하였는데 만약 숨겨야 할 것 같다면 말씀해주세요. 
- 문서에 나와있긴 하지만 `middleware` 리스트에서 `CORS middleware` 가 다른 특정 미들웨어보다 위쪽(먼저)에 위치해야 하기에, 그냥 맨 위에 넣었습니다. 

## 나중에 추가로 해결/개선해야하는 사항
- 도메인 달면 해당 주소도 추가하기
