### PR TITLE
[FEAT] #34 : remove-ip-address

### DIFF
--- a/sharkle/sharkle/settings/production.py
+++ b/sharkle/sharkle/settings/production.py
@@ -2,7 +2,7 @@ from sharkle.settings.base import *
 
 DEBUG = False
 
-ALLOWED_HOSTS = ["127.0.0.1", "54.180.162.219", "sharkle-server.kro.kr"]
+ALLOWED_HOSTS = ["127.0.0.1", "sharkle-server.kro.kr"]
 
 DATABASES = {
     "default": {


### PR DESCRIPTION
Resolves #34

## 해결/개선하고자 한 기능 설명
ec2의 접속문제(사실 이걸 해결해야하는데 원인을 못찾겠습니다.)가 지속되어 ec2를 재시작하는 경우가 많아져 아예 allowed호스트에서 ip를 제거하고 도메인으로만 접속가능하게 수정하였습니다.

## 나중에 추가로 해결/개선해야하는 사항
ec2접속문제가 혹시 용량문제인가 해서 스왑파일로 추가 용량 만들어둔 상태입니다. 계속 접속문제가 지속되면.. 확인해보겠습니다.
