### PR TITLE
Feat: [#40] user signup & login test

### DIFF
--- a/.github/workflows/django_CI.yml
+++ b/.github/workflows/django_CI.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:
-        python-version: 3.8.10
+        python-version: 3.8.10    
     - name: Install Dependencies
       run: |
         python -m pip install --upgrade pip
@@ -38,7 +38,7 @@ jobs:
       env:
           SYSTEM_ENV: GITHUB_WORKFLOW
           SECRET_KEY: '#20i1gz6%r9ri94hv^f(kz*%o80@x!anpp%qcc_+k&s^*63n1$' #Auto generated seceret key, doesn't have any mean
-          DB_USER: 'sharkle-test'
-          DB_PASSWORD: 'seminar'
+          DB_USER: 'root'
+          DB_PASSWORD: 'password'
           DB_HOST: '127.0.0.1'
       working-directory: ./sharkle

--- a/.github/workflows/django_CI.yml
+++ b/.github/workflows/django_CI.yml
@@ -38,7 +38,7 @@ jobs:
       env:
           SYSTEM_ENV: GITHUB_WORKFLOW
           SECRET_KEY: '#20i1gz6%r9ri94hv^f(kz*%o80@x!anpp%qcc_+k&s^*63n1$' #Auto generated seceret key, doesn't have any mean
-          DB_USER: 'sharkle-CI-User'
-          DB_PASSWORD: 'sharkleCI-test-DB'
-          DB_HOST: 'rds'
+          DB_USER: 'sharkle-test'
+          DB_PASSWORD: 'seminar'
+          DB_HOST: '127.0.0.1'
       working-directory: ./sharkle

--- a/sharkle/requirements.txt
+++ b/sharkle/requirements.txt
@@ -10,3 +10,4 @@ djangorestframework-simplejwt==5.0.0
 django-cors-headers==3.11.0
 black==22.1.0
 pre-commit==2.17.0
+factory-boy==3.2.1

--- a/sharkle/sharkle/settings/development.py
+++ b/sharkle/sharkle/settings/development.py
@@ -4,23 +4,23 @@ from sharkle.settings.base import *
 DEBUG = True
 
 if DEBUG:
-    INSTALLED_APPS.append('debug_toolbar')
-    MIDDLEWARE.append('debug_toolbar.middleware.DebugToolbarMiddleware')
-    INTERNAL_IPS = ['127.0.0.1']
+    INSTALLED_APPS.append("debug_toolbar")
+    MIDDLEWARE.append("debug_toolbar.middleware.DebugToolbarMiddleware")
+    INTERNAL_IPS = ["127.0.0.1"]
 
 ALLOWED_HOSTS = []
 
 DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.mysql',
-        'HOST': 'localhost',
-        'PORT': 3306,
-        'NAME': 'sharkle',
-        'USER': os.environ.get(('DB_USER')),
-        'PASSWORD': os.environ.get(('DB_PASSWORD')),
-        'OPTIONS': { # for emoji
-            'charset': 'utf8mb4',
-            'use_unicode': True,
+    "default": {
+        "ENGINE": "django.db.backends.mysql",
+        "HOST": "127.0.0.1",
+        "PORT": 3306,
+        "NAME": "sharkle",
+        "USER": os.environ.get(("DB_USER")),
+        "PASSWORD": os.environ.get(("DB_PASSWORD")),
+        "OPTIONS": {  # for emoji
+            "charset": "utf8mb4",
+            "use_unicode": True,
         },
     }
 }

--- a/sharkle/user/test_auth.py
+++ b/sharkle/user/test_auth.py
@@ -1,0 +1,114 @@
+from django.test import TestCase
+from factory.django import DjangoModelFactory
+from rest_framework_simplejwt.tokens import RefreshToken
+
+from user.models import User
+from rest_framework import status
+
+
+class UserFactory(DjangoModelFactory):
+    class Meta:
+        model = User
+
+    @classmethod
+    def create(cls, **kwargs):
+        user = User.objects.create_user(**kwargs)
+        return user
+
+
+# Create your tests here.
+class PostSignUpTestCase(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = UserFactory(
+            email="signup@sharkle.com",
+            user_id="signup",
+            username="signup",
+            password="password",
+        )
+
+        cls.default_data = {"username": "sharkle", "password": "password"}
+
+    def test_user_field_conflict(self):
+        data = self.default_data.copy()
+        data.update({"email": "signup@sharkle.com", "user_id": "new_id"})
+        response = self.client.post(
+            "/api/v1/auth/signup/", data=data, content_type="application/json"
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(User.objects.count(), 1)
+        response_data = response.json()
+        self.assertEqual(["이미 가입된 이메일입니다."], response_data["email"])
+
+    def test_missing_required_field(self):
+        response = self.client.post(
+            "/api/v1/auth/signup/",
+            data=self.default_data,
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(User.objects.count(), 1)
+
+    def test_wrong_email_format(self):
+        data = self.default_data.copy()
+        data.update({"email": "invalid_format", "user_id": "email_invalid_user"})
+        response = self.client.post(
+            "/api/v1/auth/signup/", data=data, content_type="application/json"
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(User.objects.count(), 1)
+        response_data = response.json()
+        self.assertEqual(["Enter a valid email address."], response_data["email"])
+
+    def test_signup_success(self):
+        data = {
+            "email": "success@sharkle.com",
+            "user_id": "success",
+            "username": "success",
+            "password": "password",
+        }
+        response = self.client.post(
+            "/api/v1/auth/signup/", data=data, content_type="application/json"
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+        response_data = response.json()
+        self.assertIn("refresh", response_data)
+        self.assertIn("access", response_data)
+        self.assertEqual(User.objects.count(), 2)
+
+
+class PostLoginTestCase(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = UserFactory(
+            email="login@sharkle.com",
+            user_id="login",
+            username="login",
+            password="password",
+        )
+
+    def test_login_fail(self):
+        data = {"email": "login@sharkle.com", "password": "wrong!!!!"}
+        response = self.client.post(
+            "/api/v1/auth/login/", data=data, content_type="application/json"
+        )
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        response_data = response.json()
+        self.assertEqual(
+            response_data["detail"],
+            "No active account found with the given credentials",
+        )
+
+    def test_login_success(self):
+        data = {"email": "login@sharkle.com", "password": "password"}
+        response = self.client.post(
+            "/api/v1/auth/login/", data=data, content_type="application/json"
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        response_data = response.json()
+        self.assertIn("refresh", response_data)
+        self.assertIn("access", response_data)


### PR DESCRIPTION
Resolves #40 #42

## 해결/개선하고자 한 기능 설명
- signup, login api 테스트 코드 작성
- CI mysql socket error

## 실제로 해결/개선한 방식
- 테스트 확인하려고 그냥 이 브랜치에서 workflow 수정하고 `settings.sharkle.development`의 host `127.0.0.1`로 수정했습니다.  

## 나중에 추가로 해결/개선해야하는 사항
- ~현재 CI db 관련 에러가 떠서 테스트 자체가 제대로 되지 않는데요 .. (로컬에서 테스트 돌리면 성공합니다) 별도 브랜치로 작업하는 게 좋지 않을까 싶어서 일단 pr 올립니다.~

