### PR TITLE
68/exception message

### DIFF
--- a/sharkle/common/exception_response.py
+++ b/sharkle/common/exception_response.py
@@ -29,7 +29,8 @@ class ErrorCode(Enum):
 
     DATA_NOT_FOUND = 4000  # NOT used
     CIRCLE_NOT_FOUND = 4001
-    BOARD_NOT_FOUND = 4001
+    BOARD_NOT_FOUND = 4002
+    USER_NOT_FOUND = 4003
 
     CONFLICT = 9000  # NOT used
 

--- a/sharkle/common/exception_response.py
+++ b/sharkle/common/exception_response.py
@@ -1,0 +1,36 @@
+from enum import Enum
+
+from rest_framework.response import Response
+
+
+class ExceptionResponse:
+    status = None
+    detail = ""
+    code = 0
+
+    def __init__(self, status, detail, code):
+        self.status = status
+        self.detail = detail
+        self.code = code
+
+    def to_response(self):
+        return Response(
+            status=self.status, data={"detail": self.message, "code": self.code}
+        )
+
+
+class ErrorCode(Enum):
+    INVALID_REQUEST = 0  # NOT used
+    BOARD_NOT_IN_CIRCLE = 1
+
+    NOT_ALLOWED = 3000  # NOT used
+    NOT_MEMBER = 3001
+    NOT_MANAGER = 3002
+
+    DATA_NOT_FOUND = 4000  # NOT used
+    CIRCLE_NOT_FOUND = 4001
+    BOARD_NOT_FOUND = 4001
+
+    CONFLICT = 9000  # NOT used
+
+    SERVER_ERROR = 10000  # NOT used

--- a/sharkle/common/exception_response.py
+++ b/sharkle/common/exception_response.py
@@ -15,7 +15,8 @@ class ExceptionResponse:
 
     def to_response(self):
         return Response(
-            status=self.status, data={"detail": self.message, "code": self.code}
+            status=self.status,
+            data={"status": self.status, "detail": self.message, "code": self.code},
         )
 
 
@@ -31,7 +32,10 @@ class ErrorCode(Enum):
     CIRCLE_NOT_FOUND = 4001
     BOARD_NOT_FOUND = 4002
     USER_NOT_FOUND = 4003
+    RECRUITMENT_NOT_FOUND = 4004
+    SCHEDULE_NOT_FOUND = 4005
 
     CONFLICT = 9000  # NOT used
+    PAGINATION_FAULT = 9001
 
     SERVER_ERROR = 10000  # NOT used

--- a/sharkle/hashtag/views.py
+++ b/sharkle/hashtag/views.py
@@ -1,9 +1,9 @@
 from rest_framework import serializers, status, viewsets, permissions
 from rest_framework.response import Response
+
+from common.exception_response import ExceptionResponse, ErrorCode
 from .serializers import *
 from .models import *
-from django.db.models import Q
-from user.models import User
 
 
 class HashTagViewSet(viewsets.GenericViewSet):
@@ -21,7 +21,11 @@ class HashTagViewSet(viewsets.GenericViewSet):
             )
             return self.get_paginated_response(serializer.data)
         else:
-            return Response(status=status.HTTP_400_BAD_REQUEST, data="pagination fault")
+            return ExceptionResponse(
+                status=status.HTTP_400_BAD_REQUEST,
+                detail="Page is None",
+                code=ErrorCode.PAGINATION_FAULT,
+            ).to_response()
 
     def get_queryset(self):
         return Hashtag.objects.all()

--- a/sharkle/recruitment/views.py
+++ b/sharkle/recruitment/views.py
@@ -1,29 +1,46 @@
-from django.shortcuts import render
-from rest_framework import serializers, status, viewsets, permissions
+from rest_framework import viewsets, permissions
 from rest_framework.response import Response
+
+from common.exception_response import ExceptionResponse, ErrorCode
 from .serializers import *
+
 
 # Create your views here.
 class RecruitmentViewSet(viewsets.GenericViewSet):
     serializer_class = RecruitmentSerializer
     permission_classes = (permissions.AllowAny,)  # 테스트용 임시
 
-    #GET circle/{id}/recruitment/{default, id}/
+    # GET circle/{id}/recruitment/{default, id}/
     def retrieve(self, request, circle_id, pk):
         if not (circle := Circle.objects.get_or_none(id=circle_id)):
-            return Response(status=status.HTTP_404_NOT_FOUND, data={"error": "wrong_id", "detail": "동아리가 존재하지 않습니다."})
+            return ExceptionResponse(
+                status=status.HTTP_404_NOT_FOUND,
+                detail="id: " + str(circle_id) + "에 해당하는 동아리가 존재하지 않습니다.",
+                code=ErrorCode.CIRCLE_NOT_FOUND,
+            ).to_response()
 
-        if pk == 'default':
+        if pk == "default":
             recruitments = Recruitment.objects.filter(circle=circle)
             if not recruitments:
-                Response(status=status.HTTP_404_NOT_FOUND, data={"error": "wrong_id", "detail": "Recruitment가 존재하지 않습니다."})
+                return ExceptionResponse(
+                    status=status.HTTP_404_NOT_FOUND,
+                    detail="해당 동아리에 Recruitment가 존재하지 않습니다.",
+                    code=ErrorCode.RECRUITMENT_NOT_FOUND,
+                ).to_response()
             recruitment = recruitments.last()
         elif not (recruitment := Recruitment.objects.get_or_none(id=pk, circle=circle)):
-            return Response(status=status.HTTP_404_NOT_FOUND, data={"error": "wrong_id", "detail": "Recruitment가 존재하지 않습니다."})
+            return ExceptionResponse(
+                status=status.HTTP_404_NOT_FOUND,
+                detail="id: " + str(pk) + "에 해당하는 Recruitment가 존재하지 않습니다.",
+                code=ErrorCode.RECRUITMENT_NOT_FOUND,
+            ).to_response()
 
-        return Response(status=status.HTTP_201_CREATED, data=RecruitmentViewSerializer(recruitment).data)
+        return Response(
+            status=status.HTTP_201_CREATED,
+            data=RecruitmentViewSerializer(recruitment).data,
+        )
 
-    #GET circle/{id}/recruitment/
+    # GET circle/{id}/recruitment/
     def list(self, request, circle_id):
 
         queryset = self.get_queryset()
@@ -31,10 +48,16 @@ class RecruitmentViewSet(viewsets.GenericViewSet):
 
         page = self.paginate_queryset(queryset)
         if page is not None:
-            serializer = RecruitmentViewSerializer(page, many=True, context={'request': request})
+            serializer = RecruitmentViewSerializer(
+                page, many=True, context={"request": request}
+            )
             return self.get_paginated_response(serializer.data)
         else:
-            return Response(status=status.HTTP_400_BAD_REQUEST, data="pagination fault")
+            return ExceptionResponse(
+                status=status.HTTP_400_BAD_REQUEST,
+                detail="Page is None",
+                code=ErrorCode.PAGINATION_FAULT,
+            ).to_response()
 
     def get_queryset(self):
         return Recruitment.objects.all()
@@ -43,50 +66,82 @@ class RecruitmentViewSet(viewsets.GenericViewSet):
     def create(self, request, circle_id):
 
         data = request.data.copy()
-        data['circle'] = circle_id
+        data["circle"] = circle_id
 
-        serializer = self.get_serializer(data=data, context={'request': request})
+        serializer = self.get_serializer(data=data, context={"request": request})
         serializer.is_valid(raise_exception=True)
         recruitment = serializer.save()
 
-        return Response(status=status.HTTP_201_CREATED, data=RecruitmentViewSerializer(recruitment).data)
+        return Response(
+            status=status.HTTP_201_CREATED,
+            data=RecruitmentViewSerializer(recruitment).data,
+        )
 
     # PUT circle/{id}/recruitment/{default, id}
     def update(self, request, circle_id, pk):
 
         if not (circle := Circle.objects.get_or_none(id=circle_id)):
-            return Response(status=status.HTTP_404_NOT_FOUND, data={"error": "wrong_id", "detail": "동아리가 존재하지 않습니다."})
+            return ExceptionResponse(
+                status=status.HTTP_404_NOT_FOUND,
+                detail="id: " + str(circle_id) + "에 해당하는 동아리가 존재하지 않습니다.",
+                code=ErrorCode.CIRCLE_NOT_FOUND,
+            ).to_response()
 
-        if pk == 'default':
+        if pk == "default":
             recruitments = Recruitment.objects.filter(circle=circle)
             if not recruitments:
-                Response(status=status.HTTP_404_NOT_FOUND, data={"error": "wrong_id", "detail": "Recruitment가 존재하지 않습니다."})
+                return ExceptionResponse(
+                    status=status.HTTP_404_NOT_FOUND,
+                    detail="해당 동아리에 Recruitment가 존재하지 않습니다.",
+                    code=ErrorCode.RECRUITMENT_NOT_FOUND,
+                ).to_response()
             recruitment = recruitments.last()
         elif not (recruitment := Recruitment.objects.get_or_none(id=pk, circle=circle)):
-            return Response(status=status.HTTP_404_NOT_FOUND, data={"error": "wrong_id", "detail": "Recruitment가 존재하지 않습니다."})
+            return ExceptionResponse(
+                status=status.HTTP_404_NOT_FOUND,
+                detail="id: " + str(pk) + "에 해당하는 Recruitment가 존재하지 않습니다.",
+                code=ErrorCode.RECRUITMENT_NOT_FOUND,
+            ).to_response()
 
         serializer = RecruitmentUpdateSerializer(recruitment, data=request.data)
         serializer.is_valid(raise_exception=True)
         serializer.update(recruitment, serializer.validated_data)
 
-        return Response(status=status.HTTP_200_OK, data=RecruitmentViewSerializer(recruitment).data)
+        return Response(
+            status=status.HTTP_200_OK, data=RecruitmentViewSerializer(recruitment).data
+        )
 
     # DELETE circle/{id}/recruitment/{default, id}
     def destroy(self, request, circle_id, pk):
         if not (circle := Circle.objects.get_or_none(id=circle_id)):
-            return Response(status=status.HTTP_404_NOT_FOUND, data={"error": "wrong_id", "detail": "동아리가 존재하지 않습니다."})
+            return ExceptionResponse(
+                status=status.HTTP_404_NOT_FOUND,
+                detail="id: " + str(circle_id) + "에 해당하는 동아리가 존재하지 않습니다.",
+                code=ErrorCode.CIRCLE_NOT_FOUND,
+            ).to_response()
 
-        if pk == 'default':
+        if pk == "default":
             recruitments = Recruitment.objects.filter(circle=circle)
             if not recruitments:
-                Response(status=status.HTTP_404_NOT_FOUND, data={"error": "wrong_id", "detail": "Recruitment가 존재하지 않습니다."})
+                return ExceptionResponse(
+                    status=status.HTTP_404_NOT_FOUND,
+                    detail="해당 동아리에 Recruitment가 존재하지 않습니다.",
+                    code=ErrorCode.RECRUITMENT_NOT_FOUND,
+                ).to_response()
             recruitment = recruitments.last()
         elif not (recruitment := Recruitment.objects.get_or_none(id=pk, circle=circle)):
-            return Response(status=status.HTTP_404_NOT_FOUND, data={"error": "wrong_id", "detail": "Recruitment가 존재하지 않습니다."})
+            return ExceptionResponse(
+                status=status.HTTP_404_NOT_FOUND,
+                detail="id: " + str(pk) + "에 해당하는 Recruitment가 존재하지 않습니다.",
+                code=ErrorCode.RECRUITMENT_NOT_FOUND,
+            ).to_response()
 
         recruitment.delete()
 
-        return Response(status=status.HTTP_200_OK, data={"detail": "deleted successfully"})
+        return Response(
+            status=status.HTTP_200_OK, data={"detail": "deleted successfully"}
+        )
+
 
 class RecruitScheduleViewSet(viewsets.GenericViewSet):
     serializer_class = RecruitScheduleSerializer
@@ -97,12 +152,16 @@ class RecruitScheduleViewSet(viewsets.GenericViewSet):
         if not (circle := Circle.objects.get_or_none(id=circle_id)):
             return {"circle": None, "recruitment": None}
 
-        if recruitment_id == 'default':
+        if recruitment_id == "default":
             recruitments = Recruitment.objects.filter(circle=circle)
             if not recruitments:
                 return {"circle": circle, "recruitment": None}
             recruitment = recruitments.last()
-        elif not (recruitment := Recruitment.objects.get_or_none(id=recruitment_id, circle=circle)):
+        elif not (
+            recruitment := Recruitment.objects.get_or_none(
+                id=recruitment_id, circle=circle
+            )
+        ):
             return {"circle": circle, "recruitment": None}
 
         return {"circle": circle, "recruitment": recruitment}
@@ -113,16 +172,39 @@ class RecruitScheduleViewSet(viewsets.GenericViewSet):
         data = self.get_circle_recruitment(circle_id, recruitment_id)
         circle, recruitment = data["circle"], data["recruitment"]
 
-        for i in ['circle', 'recruitment']:
+        for i in ["circle", "recruitment"]:
             if not data[i]:
-                return Response(status=status.HTTP_404_NOT_FOUND,
-                                data={"error": "wrong_id", "detail": i+"이 존재하지 않습니다."})
+                if i == "circle":
+                    return ExceptionResponse(
+                        status=status.HTTP_404_NOT_FOUND,
+                        detail="id: " + str(circle_id) + "에 해당하는 동아리가 존재하지 않습니다.",
+                        code=ErrorCode.CIRCLE_NOT_FOUND,
+                    ).to_response()
 
-        if not (schedule := RecruitmentSchedule.objects.get_or_none(id=pk, recruitment=recruitment)):
-            return Response(status=status.HTTP_404_NOT_FOUND,
-                            data={"error": "wrong_id", "detail": "Schedule이 존재하지 않습니다."})
+                else:
+                    return ExceptionResponse(
+                        status=status.HTTP_404_NOT_FOUND,
+                        detail="id: "
+                        + str(recruitment_id)
+                        + "에 해당하는 Recruitment가 존재하지 않습니다.",
+                        code=ErrorCode.RECRUITMENT_NOT_FOUND,
+                    ).to_response()
 
-        return Response(status=status.HTTP_201_CREATED, data=RecruitScheduleViewSerializer(schedule).data)
+        if not (
+            schedule := RecruitmentSchedule.objects.get_or_none(
+                id=pk, recruitment=recruitment
+            )
+        ):
+            return ExceptionResponse(
+                status=status.HTTP_404_NOT_FOUND,
+                detail="Schedule이 존재하지 않습니다.",
+                code=ErrorCode.SCHEDULE_NOT_FOUND,
+            ).to_response()
+
+        return Response(
+            status=status.HTTP_201_CREATED,
+            data=RecruitScheduleViewSerializer(schedule).data,
+        )
 
     # DELETE circle/{id}/recruitment/{id}/schedule/{id}
     def destroy(self, request, circle_id, recruitment_id, pk):
@@ -130,18 +212,40 @@ class RecruitScheduleViewSet(viewsets.GenericViewSet):
         data = self.get_circle_recruitment(circle_id, recruitment_id)
         circle, recruitment = data["circle"], data["recruitment"]
 
-        for i in ['circle', 'recruitment']:
+        for i in ["circle", "recruitment"]:
             if not data[i]:
-                return Response(status=status.HTTP_404_NOT_FOUND,
-                                data={"error": "wrong_id", "detail": i + "이 존재하지 않습니다."})
+                if i == "circle":
+                    return ExceptionResponse(
+                        status=status.HTTP_404_NOT_FOUND,
+                        detail="id: " + str(pk) + "에 해당하는 동아리가 존재하지 않습니다.",
+                        code=ErrorCode.CIRCLE_NOT_FOUND,
+                    ).to_response()
 
-        if not (schedule := RecruitmentSchedule.objects.get_or_none(id=pk, recruitment=recruitment)):
-            return Response(status=status.HTTP_404_NOT_FOUND,
-                            data={"error": "wrong_id", "detail": "Schedule이 존재하지 않습니다."})
+                else:
+                    return ExceptionResponse(
+                        status=status.HTTP_404_NOT_FOUND,
+                        detail="id: "
+                        + str(recruitment_id)
+                        + "에 해당하는 Recruitment가 존재하지 않습니다.",
+                        code=ErrorCode.RECRUITMENT_NOT_FOUND,
+                    ).to_response()
+
+        if not (
+            schedule := RecruitmentSchedule.objects.get_or_none(
+                id=pk, recruitment=recruitment
+            )
+        ):
+            return ExceptionResponse(
+                status=status.HTTP_404_NOT_FOUND,
+                detail="Schedule이 존재하지 않습니다.",
+                code=ErrorCode.SCHEDULE_NOT_FOUND,
+            ).to_response()
 
         schedule.delete()
 
-        return Response(status=status.HTTP_200_OK, data={"detail": "deleted successfully"})
+        return Response(
+            status=status.HTTP_200_OK, data={"detail": "deleted successfully"}
+        )
 
     # GET circle/{id}/recruitment/{id}/schedule/
     def list(self, request, circle_id, recruitment_id):
@@ -149,20 +253,39 @@ class RecruitScheduleViewSet(viewsets.GenericViewSet):
         data = self.get_circle_recruitment(circle_id, recruitment_id)
         circle, recruitment = data["circle"], data["recruitment"]
 
-        for i in ['circle', 'recruitment']:
+        for i in ["circle", "recruitment"]:
             if not data[i]:
-                return Response(status=status.HTTP_404_NOT_FOUND,
-                                data={"error": "wrong_id", "detail": i + "이 존재하지 않습니다."})
+                if i == "circle":
+                    return ExceptionResponse(
+                        status=status.HTTP_404_NOT_FOUND,
+                        detail="id: " + str(circle_id) + "에 해당하는 동아리가 존재하지 않습니다.",
+                        code=ErrorCode.CIRCLE_NOT_FOUND,
+                    ).to_response()
+
+                else:
+                    return ExceptionResponse(
+                        status=status.HTTP_404_NOT_FOUND,
+                        detail="id: "
+                        + str(recruitment_id)
+                        + "에 해당하는 Recruitment가 존재하지 않습니다.",
+                        code=ErrorCode.RECRUITMENT_NOT_FOUND,
+                    ).to_response()
 
         queryset = self.get_queryset()
         queryset = queryset.filter(recruitment=recruitment)
 
         page = self.paginate_queryset(queryset)
         if page is not None:
-            serializer = RecruitScheduleViewSerializer(page, many=True, context={'request': request})
+            serializer = RecruitScheduleViewSerializer(
+                page, many=True, context={"request": request}
+            )
             return self.get_paginated_response(serializer.data)
         else:
-            return Response(status=status.HTTP_400_BAD_REQUEST, data="pagination fault")
+            return ExceptionResponse(
+                status=status.HTTP_400_BAD_REQUEST,
+                detail="Page is None",
+                code=ErrorCode.PAGINATION_FAULT,
+            ).to_response()
 
     def get_queryset(self):
         return RecruitmentSchedule.objects.all()
@@ -173,37 +296,76 @@ class RecruitScheduleViewSet(viewsets.GenericViewSet):
         data = self.get_circle_recruitment(circle_id, recruitment_id)
         circle, recruitment = data["circle"], data["recruitment"]
 
-        for i in ['circle', 'recruitment']:
+        for i in ["circle", "recruitment"]:
             if not data[i]:
-                return Response(status=status.HTTP_404_NOT_FOUND,
-                                data={"error": "wrong_id", "detail": i + "이 존재하지 않습니다."})
+                if i == "circle":
+                    return ExceptionResponse(
+                        status=status.HTTP_404_NOT_FOUND,
+                        detail="id: " + str(circle_id) + "에 해당하는 동아리가 존재하지 않습니다.",
+                        code=ErrorCode.CIRCLE_NOT_FOUND,
+                    ).to_response()
+
+                else:
+                    return ExceptionResponse(
+                        status=status.HTTP_404_NOT_FOUND,
+                        detail="id: "
+                        + str(recruitment_id)
+                        + "에 해당하는 Recruitment가 존재하지 않습니다.",
+                        code=ErrorCode.RECRUITMENT_NOT_FOUND,
+                    ).to_response()
 
         data = request.data.copy()
-        data['recruitment'] = recruitment.id
+        data["recruitment"] = recruitment.id
 
-        serializer = self.get_serializer(data=data, context={'request': request})
+        serializer = self.get_serializer(data=data, context={"request": request})
         serializer.is_valid(raise_exception=True)
         recruitment_schedule = serializer.save()
 
-        return Response(status=status.HTTP_201_CREATED, data=RecruitScheduleViewSerializer(recruitment_schedule).data)
+        return Response(
+            status=status.HTTP_201_CREATED,
+            data=RecruitScheduleViewSerializer(recruitment_schedule).data,
+        )
 
-    #PUT circle/{id}/recruitment/{id}/schedule/{id}
+    # PUT circle/{id}/recruitment/{id}/schedule/{id}
     def update(self, request, circle_id, recruitment_id, pk):
 
         data = self.get_circle_recruitment(circle_id, recruitment_id)
         circle, recruitment = data["circle"], data["recruitment"]
 
-        for i in ['circle', 'recruitment']:
+        for i in ["circle", "recruitment"]:
             if not data[i]:
-                return Response(status=status.HTTP_404_NOT_FOUND,
-                                data={"error": "wrong_id", "detail": i + "이 존재하지 않습니다."})
+                if i == "circle":
+                    return ExceptionResponse(
+                        status=status.HTTP_404_NOT_FOUND,
+                        detail="id: " + str(circle_id) + "에 해당하는 동아리가 존재하지 않습니다.",
+                        code=ErrorCode.CIRCLE_NOT_FOUND,
+                    ).to_response()
 
-        if not (schedule := RecruitmentSchedule.objects.get_or_none(id=pk, recruitment=recruitment)):
-            return Response(status=status.HTTP_404_NOT_FOUND,
-                            data={"error": "wrong_id", "detail": "Schedule이 존재하지 않습니다."})
+                else:
+                    return ExceptionResponse(
+                        status=status.HTTP_404_NOT_FOUND,
+                        detail="id: "
+                        + str(recruitment_id)
+                        + "에 해당하는 Recruitment가 존재하지 않습니다.",
+                        code=ErrorCode.RECRUITMENT_NOT_FOUND,
+                    ).to_response()
+
+        if not (
+            schedule := RecruitmentSchedule.objects.get_or_none(
+                id=pk, recruitment=recruitment
+            )
+        ):
+            return ExceptionResponse(
+                status=status.HTTP_404_NOT_FOUND,
+                detail="Schedule이 존재하지 않습니다.",
+                code=ErrorCode.SCHEDULE_NOT_FOUND,
+            ).to_response()
 
         serializer = RecruitScheduleUpdateSerializer(schedule, data=request.data)
         serializer.is_valid(raise_exception=True)
         serializer.update(schedule, serializer.validated_data)
 
-        return Response(status=status.HTTP_201_CREATED, data=RecruitScheduleViewSerializer(schedule).data)
+        return Response(
+            status=status.HTTP_201_CREATED,
+            data=RecruitScheduleViewSerializer(schedule).data,
+        )


### PR DESCRIPTION
Resolves #\<issue No.1\>, #\<issue No.2\> ...

## 해결/개선하고자 한 기능 설명
Exception message와 에러 코드를 통일하여 사용할 수 있도록 변경하였습니다.

## 실제로 해결/개선한 방식
exception_response 파일에 에러 코드들이 있으며 1000단위로 끝나는 코드는 사용하지 않는 base코드이고 필요한 새로운 에러가 존재하면 순서에 맞게 새로 생성하여 쓰시면 됩니다.

또한 ExceptionResponse라는 새로운 클래스를 정의하였습니다. 만약 Exception을 response로 리턴할 일이 생길 경우 위의 새롭게 정의한 클래스를 코드와 메시지 status를 이용하여 먼저 선언하고 to_response 메소드를 이용하여 리턴하시면 됩니다. 

Exception처리의 일관성을 위하여 위와 같이 설정하였습니다. 혹시 좋은 다른 방법이 있으면 알려주시면 감사하겠습니다. 

## 나중에 추가로 해결/개선해야하는 사항
Exception 처리뿐만아니라 성공한 response를 리턴할 때도 통일이 필요할 것 같습니다.
