### PR TITLE
response enum to int

### DIFF
--- a/sharkle/common/exception_response.py
+++ b/sharkle/common/exception_response.py
@@ -16,7 +16,11 @@ class ExceptionResponse:
     def to_response(self):
         return Response(
             status=self.status,
-            data={"status": self.status, "detail": self.message, "code": self.code},
+            data={
+                "status": self.status,
+                "detail": self.detail,
+                "code": self.code.value,
+            },
         )
 
 


### PR DESCRIPTION
Resolves #68 

## 해결/개선하고자 한 기능 설명
erro code가 enum형태로 존재하는데 이 상태로는 데이터로 반환할 수 없어 enum을 int로 전환 후 리턴

