### PR TITLE
동아리의 이름으로 게시판 목록화

### DIFF
--- a/sharkle/board/serializers.py
+++ b/sharkle/board/serializers.py
@@ -7,3 +7,10 @@ class BoardSerializer(serializers.ModelSerializer):
         # num_of_articles ...
         model = Board
         fields = ("id", "name", "circle", "is_private", "created_at", "updated_at")
+
+
+class BoardSimpleSerializer(serializers.ModelSerializer):
+    class Meta:
+        # num_of_articles ...
+        model = Board
+        fields = ("id", "name")

--- a/sharkle/board/urls.py
+++ b/sharkle/board/urls.py
@@ -1,6 +1,6 @@
 from django.urls import include, path
 from rest_framework.routers import SimpleRouter
-from board.views import BoardViewSet
+from board.views import *
 
 app_name = "board"
 
@@ -9,4 +9,5 @@ router.register(r"circle/(?P<circle_id>\d+)/board", BoardViewSet, basename="boar
 
 urlpatterns = [
     path("", include(router.urls)),
+    path("circle/<str:circle_name>/board/", get_board_list_by_circle_name),
 ]

--- a/sharkle/board/views.py
+++ b/sharkle/board/views.py
@@ -4,9 +4,9 @@ from rest_framework.response import Response
 
 from board.BoardPermission import BoardPermission
 from board.models import Board
-from board.serializers import BoardSerializer
+from board.serializers import *
 
-from circle.models import Circle, UserCircle_Member
+from circle.models import Circle
 from circle.permission import UserCirclePermission
 
 # 1. check circle_id existence
@@ -189,7 +189,7 @@ def get_board_list_by_circle_name(request, circle_name):
     member = UserCirclePermission(user.id, circle.id)
     if not member.is_member():  # 멤버가 아니면 비공게 게시판 숨기기
         boards = Board.objects.filter(circle=circle.id, is_private=False)
-        return Response(BoardSerializer(boards, many=True).data)
+        return Response(BoardSimpleSerializer(boards, many=True).data)
     else:  # 멤버면 모든 게시판 공개
         boards = Board.objects.filter(circle=circle.id)
-        return Response(BoardSerializer(boards, many=True).data)
+        return Response(BoardSimpleSerializer(boards, many=True).data)


### PR DESCRIPTION
Resolves #71

## 해결/개선하고자 한 기능 설명
동아리의 아이디가 아닌 이름으로 게시판을 목록화 할 수 있도록 api 추가

## 실제로 해결/개선한 방식
GET /circle/{circle_name}/board/ 를 새로운 개별 api get_board_list_by_circle_name으로 생성
