### PR TITLE
Feat: add GET circle by name

### DIFF
--- a/sharkle/circle/tests.py
+++ b/sharkle/circle/tests.py
@@ -1,3 +1,44 @@
+import factory
 from django.test import TestCase
+from factory.django import DjangoModelFactory
+from rest_framework_simplejwt.tokens import RefreshToken
+from circle.models import Circle
+from user.models import User
+from rest_framework import status
 
-# Create your tests here.
+
+class UserFactory(DjangoModelFactory):
+    class Meta:
+        model = User
+
+    username = factory.Sequence(lambda n: "user%d" % n)
+    email = factory.LazyAttribute(lambda o: "%s@sharkle.org" % o.username)
+    password = "1234"
+
+
+class CircleFactory(DjangoModelFactory):
+    class Meta:
+        model = Circle
+
+    name = factory.Sequence(lambda n: "Circle %d" % n)
+    bio = factory.Sequence(lambda n: "Circle %d bio" % n)
+    tag = "sample_tag"
+
+
+class GetCircleByNameTestCase(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = UserFactory()
+        cls.circle = CircleFactory()
+        cls.user_token = "Bearer " + str(RefreshToken.for_user(cls.user).access_token)
+
+    def test_get_circle_success(self):
+        response = self.client.get(
+            f"/api/v1/circle/{self.circle.name}/name/",
+            data={},
+            content_type="application/json",
+            HTTP_AUTHORIZATION=self.user_token,
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        response_data = response.json()

--- a/sharkle/circle/urls.py
+++ b/sharkle/circle/urls.py
@@ -29,4 +29,7 @@ urlpatterns = [
         intro_detail,
         name="intro_detail",
     ),
+    path(
+        "circle/<str:circle_name>/name/", CircleNameView.as_view(), name="circle_name"
+    ),
 ]


### PR DESCRIPTION
Resolves #101 

## 해결/개선하고자 한 기능 설명
- `GET circle/{id}/` 와 동일한 리스폰스를 주되 동아리 이름을 기준으로 가져오는 api `GET circle/{circle_name}/name/` 구현

## 실제로 해결/개선한 방식
- 별도의 api view, 한동님이 만들어주신 functions.py의 `find_circle_string` 활용
- 해당 api 만 test 작성

## 나중에 추가로 해결/개선해야하는 사항
- 별도의 api view 쓰는 게 약간 번거롭게 느껴지긴 했는데요, 활용하는 함수가 다르다는 점, 그리고 `GET circle/{id}` `GET circle/{circle_name}/` 이런 식으로 같은 url을 공유할 시에 url param을 서로 다른 타입으로 캡처할 수 없는 문제 때문에 이렇게 했습니다. 다른 좋은 방법 있을까요?
